### PR TITLE
fix: remove words from lerna description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ---
 
-- **[Lerna](https://lerna.js.org/):** The mothership and mother of monorepos for modern JavaScript. This repository and the npm package it provides are the base to thousands of monorepos and brought monorepos to JavaScript in a modern real way.
+- **[Lerna](https://lerna.js.org/):** The mother of monorepos for JavaScript. This repository and the npm package it provides are the base to thousands of monorepos and brought monorepos to JavaScript in a real way.
 - **[Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/):** Yarn workspaces are one option to improve monorepo development in JavaScript. Using Yarn's caching and incorporating smart linking, Yarn Workspaces does improve developer experience.
 - **[Syncpack](https://github.com/JamieMason/syncpack):** Syncpack is monorepo dependency management tool. If you've ever struggled with slight dependencies differences across packages or maintaining uniform `package.json` files, then you can imagine the usefulness of Syncpack!
 - **[Pnpm](https://pnpm.js.org/):** Pnpm is package manager which links node_modules from a single content-addressable storage making installs faster and the node_module directory size much smaller. It has workspace functionality like yarn workspaces making it a great option for monorepo development when node apps are involved.


### PR DESCRIPTION
## Fixes

- Removes unneeded words in Lerna description which should also remove the awkward word widow. 


---

> Read about referenced issues [here](https://help.github.com/articles/closing-issues-using-keywords/). Replace words with this Pull Request's context.
